### PR TITLE
Remove SAC_PIT, UPG_SKEL_LIFE from Undead builds

### DIFF
--- a/TFT/Undead/BuildSequence.ai
+++ b/TFT/Undead/BuildSequence.ai
@@ -190,7 +190,7 @@ function global_build_sequence takes nothing returns nothing
     endif
     call BuildAdvUpgr2(2, UPG_FIEND_WEB,2,TownCountDone(CRYPT_FIEND),0.33,15,85)
     call BuildAdvUpgr2(2, UPG_NECROS,2,TownCountDone(NECRO),0.33,15,95)
-    call BuildAdvUpgr2(1, UPG_SKEL_LIFE,2,TownCountDone(NECRO),0.33,15,75)
+    call BuildAdvUpgr2(1, UPG_SKEL_MASTERY,2,TownCountDone(NECRO),0.33,15,75)
     call BuildAdvUpgr2(2, UPG_BANSHEE,2,TownCountDone(BANSHEE),0.33,15,95)
 
     // TIER 3 UPGRADES
@@ -430,7 +430,6 @@ elseif tier == 2 then
       call BuildUnit(1, hero[2], 130)
       call BuildUnit(2, OBSIDIAN_STATUE, 53)
       call BuildUnit(1, NECROPOLIS_3, 65)
-      call BuildUnit(1, SAC_PIT, 30)
 
 
       call BuildUpgr(1, UPG_FIEND_WEB, 60)
@@ -511,7 +510,6 @@ if tier == 3 then
       call BuildUpgr(2, UPG_NECROS, 91)
       call BuildUpgr(1, UPG_SKEL_MASTERY, 85)
       call BuildUpgr(1, UPG_EXHUME, 65)
-      call BuildUpgr(1, UPG_SKEL_LIFE, 65)
       call BuildUpgr(1, UPG_PLAGUE, 50)
 
 
@@ -1022,7 +1020,6 @@ elseif tier == 2 then
       call BuildUnit(1, hero[1], 140)
       call BuildUnit(1, hero[2], 130)
       call BuildUnit(1, NECROPOLIS_3, 60)
-      call BuildUnit(1, SAC_PIT, 30)
 
       call BuildUnit(1, ZEPPELIN, 50)
       call BuildUpgr(1, UPG_CANNIBALIZE, 50)
@@ -1568,7 +1565,6 @@ if tier == 3 then
       call BuildUnit(1, hero[3], 120)
       call BuildUpgr(Min((TownCountDone(MEAT_WAGON) + TownCountDone(ABOMINATION))/4,1), UPG_PLAGUE, 50)
       call BuildUpgr(Min((TownCountDone(NECRO)/3),2), UPG_NECROS, 60)
-      call BuildUpgr(Min((TownCountDone(NECRO)/3),1), UPG_SKEL_LIFE, 60)
       call BuildUpgr(Min((TownCountDone(NECRO)/4),1), UPG_SKEL_MASTERY, 60)
       call BuildUpgr(Min((TownCountDone(BANSHEE)/3),2), UPG_BANSHEE, 40)
       call BuildUpgr(Min((TownCountDone(MEAT_WAGON)/2),1), UPG_EXHUME, 40)
@@ -1603,7 +1599,7 @@ elseif tier == 2 then
       call BuildUnit(1, hero[1], 130)
       call BuildUnit(1, hero[2], 120)
       call BuildUpgr(Min((TownCountDone(NECRO)/3),1), UPG_NECROS, 60)
-      call BuildUpgr(Min((TownCountDone(NECRO)/3),1), UPG_SKEL_LIFE, 50)
+      call BuildUpgr(Min((TownCountDone(NECRO)/3),1), UPG_SKEL_MASTERY, 50)
       call BuildUpgr(Min((TownCountDone(BANSHEE)/3),1), UPG_BANSHEE, 40)
       call BuildUpgr(Min((TownCountDone(MEAT_WAGON)/2),1), UPG_EXHUME, 40)
 
@@ -1722,7 +1718,6 @@ elseif tier == 2 then
       call BuildUnit(1, hero[1], 130)
       call BuildUnit(1, hero[2], 120)
       call BuildUnit(12, GHOUL, 55)
-      call BuildUnit(1, SAC_PIT, 30)
 
 
 


### PR DESCRIPTION
- Sacrificial Pit is no longer needed for Wyrms.
- Skeletal Longevity upgrade does not exist anymore.